### PR TITLE
Remove arrow from background in add a new recommendation input field

### DIFF
--- a/app/assets/stylesheets/components/_box.scss
+++ b/app/assets/stylesheets/components/_box.scss
@@ -1,7 +1,7 @@
 .box-lists {
   // background-color: black;
-  margin: 0px 5px 5px 0px;
-  padding: 15px 40px 40px 15px;
+  margin: 5px 5px 5px 0px;
+  padding: 15px 15px 40px 15px;
   border-radius: 25px;
   background-color: #f72585;
   -webkit-animation: random 5s infinite;

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -13,6 +13,10 @@
   border: none;
 }
 
+.form-select{
+  background-image: none !important;
+}
+
 input[type="text"] {
   color: white; /* Replace with your desired color */
 }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -51,13 +51,15 @@
   <div class="d-flex justify-content-start mx-3 mt-3 my-0">
     <div class="row w-100 justify-content-center">
      <div class="col-12 my-3">
+
+     <%# Search Bar %>
     <%= form_with url: home_path, method: :get, class: "d-flex" do %>
       <%= text_field_tag :query,
             params[:query],
             class: "form-control  btn-pill",
             placeholder: "search mendlies",
             style: "background-color: rgba(140, 140, 140, 0.5);
-            border:none; margin-right: 10px"%>
+            border:none; margin-right: 10px; color:white;"%>
 
             <%= submit_tag "→", name: "", class: "btn btn-outline-light btn-pill"%>
 

--- a/app/views/recommendations/new.html.erb
+++ b/app/views/recommendations/new.html.erb
@@ -5,7 +5,7 @@
 
     <%= simple_form_for(@recommendation) do |form| %>
       <div class="form-inputs text-white">
-        <%= form.association :item, label: "Name", placeholder: "Name your recommendation", input_html: { class: "form-input-border", data: {controller: "tom-select"}} %>
+        <%= form.association :item , label: "Name", placeholder: "Name your recommendation", input_html: { class: "form-input-border",data: {controller: "tom-select"}} %>
         <%= form.association :giver, label: "Mendler", label_method: :nickname, placeholder: "Who gave you this recommendation?", input_html: { class: "form-input-border", data: {controller: "tom-select"}} %>
         <%= form.input :comment, placeholder: "share your thoughts", input_html: { class: "form-input-border" } %>
 


### PR DESCRIPTION
Remove arrow from background in add a new recommendation input field, changed the alignment of the page and on  the HOME page switched the color of the input text on the search bar from black to white